### PR TITLE
Convert specs to RSpec 3.4.1 syntax with Transpec

### DIFF
--- a/spec/fixtures/config/environments/test.rb
+++ b/spec/fixtures/config/environments/test.rb
@@ -3,8 +3,10 @@ ENV['RSPEC'] = "true"
 Dor::Config.configure do
   fedora do
     url 'https://fedoraAdmin:fedoraAdmin@dor-dev.stanford.edu/fedora'
+  end
+  ssl do
     cert_file File.expand_path(File.dirname(__FILE__) + '/../../../certs/ls-dev.crt')
-    key_file File.expand_path(File.dirname(__FILE__) + '/../../../certs/ls-dev.key')
+    key_file  File.expand_path(File.dirname(__FILE__) + '/../../../certs/ls-dev.key')
     key_pass 'lsdev'
   end
 
@@ -17,7 +19,7 @@ Dor::Config.configure do
   sedora do
     "http://fedoraAdmin:fedoraAdmin@sdr-fedora-dev.stanford.edu/fedora"
     cert_file File.expand_path(File.dirname(__FILE__) + '/../../../certs/ls-dev.crt')
-    key_file File.expand_path(File.dirname(__FILE__) + '/../../../certs/ls-dev.key')
+    key_file  File.expand_path(File.dirname(__FILE__) + '/../../../certs/ls-dev.key')
     key_pass 'lsdev'
     
     deposit_dir File.expand_path(File.dirname(__FILE__)) << '/../../sdr2_example_objects'

--- a/spec/lyber_core/destroyer_spec.rb
+++ b/spec/lyber_core/destroyer_spec.rb
@@ -22,17 +22,17 @@ describe LyberCore::Destroyer do
   context "fetching druids" do
 
     it "accepts a repository, a workflow, and the name of the registration robot" do
-      @dfo.repository.should eql("dor")
-      @dfo.workflow.should eql("googleScannedBookWF")
-      @dfo.registration_robot.should eql("register-object")
+      expect(@dfo.repository).to eql("dor")
+      expect(@dfo.workflow).to eql("googleScannedBookWF")
+      expect(@dfo.registration_robot).to eql("register-object")
     end
 
     it "knows its workflow URL" do
-      Dor::Config.workflow.url.should eql("http://lyberservices-dev.stanford.edu/workflow")
+      expect(Dor::Config.workflow.url).to eql("http://lyberservices-dev.stanford.edu/workflow")
     end
 
     it "can get all the druids for a workflow" do
-      @dfo.druid_list.should =~ %w(druid:kv369fp5449 druid:ch639ch2025 druid:nr812fr7912 druid:qj817sf0765 druid:jx368wq5745 druid:gv079bw9958 druid:sz826gb8674 druid:mg674rv7413 druid:tv840tf8420 druid:dx718jt7616 druid:kw310kp8493)
+      expect(@dfo.druid_list).to match_array(%w(druid:kv369fp5449 druid:ch639ch2025 druid:nr812fr7912 druid:qj817sf0765 druid:jx368wq5745 druid:gv079bw9958 druid:sz826gb8674 druid:mg674rv7413 druid:tv840tf8420 druid:dx718jt7616 druid:kw310kp8493))
     end
 
   end
@@ -40,7 +40,7 @@ describe LyberCore::Destroyer do
   context "delete from fedora" do
 
     it "has a method that tells it to delete the druids" do
-      @dfo.should respond_to(:delete_druids)
+      expect(@dfo).to respond_to(:delete_druids)
     end
 
   end

--- a/spec/lyber_core/log_spec.rb
+++ b/spec/lyber_core/log_spec.rb
@@ -20,42 +20,42 @@ describe LyberCore::Log do
     end
 
     it "has a default value for logfile" do
-      LyberCore::Log.logfile.should eql(LyberCore::Log::DEFAULT_LOGFILE)
+      expect(LyberCore::Log.logfile).to eql(LyberCore::Log::DEFAULT_LOGFILE)
     end
 
     it "can set the location of the logfile" do
       LyberCore::Log.set_logfile(valid_logfile)
-      LyberCore::Log.logfile.should eql(valid_logfile)
+      expect(LyberCore::Log.logfile).to eql(valid_logfile)
     end
 
     it "throws an error and does not change location of logfile if passed an invalid location for a logfile" do
-      lambda { LyberCore::Log.set_logfile(invalid_logfile)}.should raise_exception(/Couldn't initialize logfile/)
-      LyberCore::Log.logfile.should eql(LyberCore::Log::DEFAULT_LOGFILE)
+      expect { LyberCore::Log.set_logfile(invalid_logfile)}.to raise_exception(/Couldn't initialize logfile/)
+      expect(LyberCore::Log.logfile).to eql(LyberCore::Log::DEFAULT_LOGFILE)
     end
 
     it "can report its log level" do
-      LyberCore::Log.should respond_to(:level)
+      expect(LyberCore::Log).to respond_to(:level)
     end
 
     it "starts in info reporting mode (log level 1)" do
-      LyberCore::Log.level.should eql(Logger::INFO)
+      expect(LyberCore::Log.level).to eql(Logger::INFO)
     end
 
     it "can be put into debug mode (log level 0)" do
       LyberCore::Log.set_level(0)
-      LyberCore::Log.level.should eql(Logger::DEBUG)
+      expect(LyberCore::Log.level).to eql(Logger::DEBUG)
     end
 
     it "goes into debug mode if it receives an invalid option for loglevel" do
       LyberCore::Log.set_level("foo")
-      LyberCore::Log.level.should eql(Logger::DEBUG)
+      expect(LyberCore::Log.level).to eql(Logger::DEBUG)
     end
 
     it "keeps the same logging level when switching to a different file" do
       LyberCore::Log.set_level(Logger::DEBUG)
       LyberCore::Log.set_logfile(LyberCore::Log::DEFAULT_LOGFILE)
       LyberCore::Log.set_logfile(valid_logfile)
-      LyberCore::Log.level.should eql(Logger::DEBUG)
+      expect(LyberCore::Log.level).to eql(Logger::DEBUG)
     end
 
 
@@ -63,51 +63,51 @@ describe LyberCore::Log do
       onetimefile = "/tmp/onetimefile"
       File.delete onetimefile if File.exists? onetimefile
       LyberCore::Log.set_logfile(onetimefile)
-      LyberCore::Log.logfile.should eql(onetimefile)
+      expect(LyberCore::Log.logfile).to eql(onetimefile)
       LyberCore::Log.set_level(3)
-      (File.file? onetimefile).should eql(true)
+      expect(File.file? onetimefile).to eql(true)
       LyberCore::Log.error("This is an error")
       LyberCore::Log.debug("Debug info 1")
       LyberCore::Log.info("This is some info")
       LyberCore::Log.error("This is another error")
       contents = open(onetimefile) { |f| f.read }
-      contents.should match(/This is an error/)
-      contents.should match(/This is another error/)
-      contents.should_not match(/This is some info/)
-      contents.should_not match(/Debug info 1/)
+      expect(contents).to match(/This is an error/)
+      expect(contents).to match(/This is another error/)
+      expect(contents).not_to match(/This is some info/)
+      expect(contents).not_to match(/Debug info 1/)
       File.delete onetimefile
-      (File.exists? onetimefile).should eql(false)
+      expect(File.exists? onetimefile).to eql(false)
     end
 
     it "prints debugging statements when in debugging mode" do
       onetimefile = "/tmp/debugfile"
       File.delete onetimefile if File.exists? onetimefile
       LyberCore::Log.set_logfile(onetimefile)
-      LyberCore::Log.logfile.should eql(onetimefile)
+      expect(LyberCore::Log.logfile).to eql(onetimefile)
       LyberCore::Log.set_level(0)
-      (File.file? onetimefile).should eql(true)
+      expect(File.file? onetimefile).to eql(true)
       LyberCore::Log.debug("Debug info 1")
       LyberCore::Log.fatal("Oh nooooo!")
       LyberCore::Log.debug("More debug stuff")
       LyberCore::Log.info("And here is some info")
       contents = open(onetimefile) { |f| f.read }
-      contents.should match(/Debug info 1/)
-      contents.should match(/Oh nooooo!/)
+      expect(contents).to match(/Debug info 1/)
+      expect(contents).to match(/Oh nooooo!/)
       File.delete onetimefile
-      (File.exists? onetimefile).should eql(false)
+      expect(File.exists? onetimefile).to eql(false)
     end
 
     it "can restore its default state" do
       LyberCore::Log.restore_defaults
-      LyberCore::Log.level.should eql(LyberCore::Log::DEFAULT_LOG_LEVEL)
-      LyberCore::Log.logfile.should eql(LyberCore::Log::DEFAULT_LOGFILE)
+      expect(LyberCore::Log.level).to eql(LyberCore::Log::DEFAULT_LOG_LEVEL)
+      expect(LyberCore::Log.logfile).to eql(LyberCore::Log::DEFAULT_LOGFILE)
     end
 
     it "can format an error message from an exception" do
       re = RuntimeError.new("runtime message")
       re.set_backtrace(caller)
       log_msg = LyberCore::Log.exception_message(re)
-      log_msg.should eql "#{re.inspect}\n" << re.backtrace.join("\n")
+      expect(log_msg).to eql "#{re.inspect}\n" << re.backtrace.join("\n")
     end
 
     it "will replace newlines with semicolons when logging an exception with a multiline message" do
@@ -115,14 +115,14 @@ describe LyberCore::Log do
       re = RuntimeError.new(msg)
       re.set_backtrace(caller)
       log_msg = LyberCore::Log.exception_message(re)
-      log_msg.should eql "#<RuntimeError: runtime; message>\n" <<  re.backtrace.join("\n")
+      expect(log_msg).to eql "#<RuntimeError: runtime; message>\n" <<  re.backtrace.join("\n")
     end
 
     it "can log information from any exception object" do
       re = RuntimeError.new("runtime message")
       re.set_backtrace(caller)
       log_msg = LyberCore::Log.exception_message(re)
-      LyberCore::Log.should_receive(:error).with(log_msg)
+      expect(LyberCore::Log).to receive(:error).with(log_msg)
       LyberCore::Log.exception(re)
     end
   end


### PR DESCRIPTION
This conversion is done by Transpec 3.1.1 with the following command:
    transpec

* 28 conversions
    from: obj.should
      to: expect(obj).to

* 2 conversions
    from: obj.should_not
      to: expect(obj).not_to

* 1 conversion
    from: =~ [1, 2]
      to: match_array([1, 2])

* 1 conversion
    from: lambda { }.should
      to: expect { }.to

* 1 conversion
    from: obj.should_receive(:message)
      to: expect(obj).to receive(:message)

For more details: https://github.com/yujinakayama/transpec#supported-conversions