### PR TITLE
Allow other return states

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,5 @@ notifications:
   email: false
 
 rvm:
+  - 2.2.4
   - 2.3.1
-  - 2.2.1
-  - 2.1.2
-

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Create a class that mixes in `LyberCore::Robot`
 
-* In the intializer, call `super` with the repository, workflow name, step name
+* In the initializer, call `super` with the repository, workflow name, step name
 * Your class `#perform` method will perform the actual work, with `druid` passed in as the one and only argument
 
 ```ruby
@@ -24,6 +24,37 @@ module Robots
         def perform druid
           obj = Dor::Item.find(druid)
           obj.shelve
+        end
+
+      end
+
+    end
+  end
+end
+```
+
+By default, the druid will be set to the completed state, but you can optionally have it set to skipped by creating a ReturnState object as shown below
+```ruby
+module Robots
+  module DorRepo
+    module Accession
+
+      class Shelve
+        include LyberCore::Robot
+
+        def initialize
+          super('dor', 'accessionWF', 'shelve')
+        end
+
+        def perform druid
+          obj = Dor::Item.find(druid)
+          if some_logic_here_to_determine_if_shelving_occurs
+            obj.shelve
+            return LyberCore::Robot::ReturnState.new('completed') # set the final state to completed
+          else
+            # just return skipped if we did nothing
+            return LyberCore::Robot::ReturnState.new('skipped') # set the final state to skipped
+          end
         end
 
       end

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/sul-dlss/lyber-core.svg?branch=master)](https://travis-ci.org/sul-dlss/lyber-core) | [![Coverage Status](https://coveralls.io/repos/github/sul-dlss/lyber-core/badge.svg?branch=master)](https://coveralls.io/github/sul-dlss/lyber-core?branch=master)
+
 # lyber_core
 
 ## Robot Creation
@@ -79,4 +81,4 @@ Resque.enqueue_to('accessionWF_shelve'.to_sym, Robot::DorRepo::Accession::Shelve
 
 ## Copyright
 
-Copyright (c) 2014 Stanford University Library. See LICENSE for details.
+Copyright (c) 2014-16 Stanford University Library. See LICENSE for details.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ module Robots
 end
 ```
 
-By default, the druid will be set to the completed state, but you can optionally have it set to skipped by creating a ReturnState object as shown below
+By default, the druid will be set to the completed state, but you can optionally have it set to skipped by creating a ReturnState object as shown below.
+You can also return custom notes in this way
 ```ruby
 module Robots
   module DorRepo
@@ -50,10 +51,13 @@ module Robots
           obj = Dor::Item.find(druid)
           if some_logic_here_to_determine_if_shelving_occurs
             obj.shelve
-            return LyberCore::Robot::ReturnState.new('completed') # set the final state to completed
+            return LyberCore::Robot::ReturnState.COMPLETED # set the final state to completed
+#           return LyberCore::Robot::ReturnState.new(state: 'completed', note: 'some custom note to pass back to workflow') # set the final state to completed with a custom note
+
           else
             # just return skipped if we did nothing
-            return LyberCore::Robot::ReturnState.new('skipped') # set the final state to skipped
+            return LyberCore::Robot::ReturnState.SKIPPED # set the final state to skipped
+#           return LyberCore::Robot::ReturnState.new(state: 'skipped', note: 'some custom note to pass back to workflow') # set the final state to skipped with a custom note
           end
         end
 

--- a/lib/lyber_core.rb
+++ b/lib/lyber_core.rb
@@ -1,2 +1,3 @@
 require 'lyber_core/log'
 require 'lyber_core/robot'
+require 'lyber_core/return_state'

--- a/lib/lyber_core/return_state.rb
+++ b/lib/lyber_core/return_state.rb
@@ -1,0 +1,23 @@
+# this object defines the allowed states robots can optionally return upon completion
+# if the return value of the "perform" step is an object of this type and the status value set an allowed value, 
+#  it will be used to set the final workflow state for that druid
+module LyberCore
+  module Robot
+    class ReturnState
+      
+      attr_reader :status
+      ALLOWED_RETURN_STATES = %w{completed skipped}
+      DEFAULT_RETURN_STATE  = 'completed'
+      
+      def initialize(value = DEFAULT_RETURN_STATE)
+        self.status=value.to_s.downcase
+      end
+      
+      def status=(value)
+        raise 'invalid return state' unless ALLOWED_RETURN_STATES.include? value.to_s.downcase
+        @status=value
+      end
+            
+    end
+  end
+end

--- a/lib/lyber_core/return_state.rb
+++ b/lib/lyber_core/return_state.rb
@@ -1,21 +1,32 @@
 # this object defines the allowed states robots can optionally return upon completion
-# if the return value of the "perform" step is an object of this type and the status value set an allowed value, 
+# if the return value of the "perform" step is an object of this type and the status value is set an allowed value, 
 #  it will be used to set the final workflow state for that druid
 module LyberCore
   module Robot
     class ReturnState
       
       attr_reader :status
+      attr_accessor :note
       ALLOWED_RETURN_STATES = %w{completed skipped}
       DEFAULT_RETURN_STATE  = 'completed'
       
-      def initialize(value = DEFAULT_RETURN_STATE)
-        self.status=value.to_s.downcase
+      def self.SKIPPED
+        self.new(status: 'skipped')
+      end
+
+      def self.COMPLETED
+        self.new(status: 'completed')
+      end
+      
+      def initialize(params = {})
+        self.status = params[:status] || DEFAULT_RETURN_STATE
+        self.note = params[:note] || ""
       end
       
       def status=(value)
-        raise 'invalid return state' unless ALLOWED_RETURN_STATES.include? value.to_s.downcase
-        @status=value
+        state = value.to_s.downcase
+        raise 'invalid return state' unless ALLOWED_RETURN_STATES.include? state
+        @status = state
       end
             
     end

--- a/lib/lyber_core/robot.rb
+++ b/lib/lyber_core/robot.rb
@@ -69,12 +69,22 @@ module LyberCore
         result = self.perform druid                                    # implemented in the mixed-in robot class
       end
 
-      # the final workflow state is determined by the return value of the perform step, if it is a ReturnState object, use the defined status, otherwise default to completed
-      workflow_state = (result.class == LyberCore::Robot::ReturnState) ? result.status : 'completed'
+      # this is the default note to pass back to workflow service, but it can be overriden by a robot that uses the Lybercore::Robot::ReturnState object to return a status
+      note = Socket.gethostname
+      
+      # the final workflow state is determined by the return value of the perform step, if it is a ReturnState object, 
+      # we will use the defined status, otherwise default to completed
+      # if a note is passed back, we will also use that instead of the default
+      if result.class == LyberCore::Robot::ReturnState
+        workflow_state = result.status
+        note = result.note unless result.note.blank?
+      else
+        workflow_state = 'completed'  
+      end
       
       # update the workflow status from 'queued' to the state returned by perform (or 'completed' as the default) 
       # NOTE errors out if current status is not queued
-      workflow_service.update_workflow_status @repo, druid, @workflow_name, @step_name, workflow_state, :elapsed => elapsed, :note => Socket.gethostname, :current_status => 'queued'
+      workflow_service.update_workflow_status @repo, druid, @workflow_name, @step_name, workflow_state, :elapsed => elapsed, :note => note, :current_status => 'queued'
       LyberCore::Log.info "Finished #{druid} in #{sprintf("%0.4f",elapsed)}s"
 
     rescue => e

--- a/lyber-core.gemspec
+++ b/lyber-core.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rdoc"
   s.add_development_dependency "rspec", '~> 3.0'
   s.add_development_dependency "yard"
+  s.add_development_dependency "coveralls"
 
   s.files        = Dir.glob("lib/**/*") + %w(LICENSE README.md)
   s.bindir       = 'bin'

--- a/spec/lyber_core/robots/return_state_spec.rb
+++ b/spec/lyber_core/robots/return_state_spec.rb
@@ -8,24 +8,43 @@ describe LyberCore::Robot::ReturnState do
   end
 
   it "should allow other return states to be set" do
-    return_state=LyberCore::Robot::ReturnState.new('completed')
+    return_state=LyberCore::Robot::ReturnState.new(status: 'completed')
     expect(return_state.status).to eq 'completed'
+    expect(return_state.note).to eq ''
     return_state=LyberCore::Robot::ReturnState.new
     return_state.status='skipped'
     expect(return_state.status).to eq 'skipped'
-    return_state=LyberCore::Robot::ReturnState.new('skipped')
+    return_state=LyberCore::Robot::ReturnState.new(status: 'skipped')
     expect(return_state.status).to eq 'skipped'
   end
   
-  it "should not care about the case or if it is symbol" do
-    return_state=LyberCore::Robot::ReturnState.new('COMPLETED')
+  it "should allow a note to be set" do
+    return_state=LyberCore::Robot::ReturnState.new(note: 'some note to be passed back to workflow')
     expect(return_state.status).to eq 'completed'
-    return_state=LyberCore::Robot::ReturnState.new(:skipped)
+    expect(return_state.note).to eq 'some note to be passed back to workflow'
+    return_state=LyberCore::Robot::ReturnState.new(status: 'skipped', note: 'some note to be passed back to workflow')
+    expect(return_state.status).to eq 'skipped'
+    expect(return_state.note).to eq 'some note to be passed back to workflow'
+  end
+  
+  it "should not care about the case or if it is symbol" do
+    return_state=LyberCore::Robot::ReturnState.new(status: 'COMPLETED')
+    expect(return_state.status).to eq 'completed'
+    return_state=LyberCore::Robot::ReturnState.new(status: :skipped)
+    expect(return_state.status).to eq 'skipped'
+    return_state=LyberCore::Robot::ReturnState.new(status: 'Skipped')
     expect(return_state.status).to eq 'skipped'
   end
 
+  it "works with ReturnState constants" do
+    return_state=LyberCore::Robot::ReturnState.SKIPPED
+    expect(return_state.status).to eq 'skipped'
+    return_state=LyberCore::Robot::ReturnState.COMPLETED
+    expect(return_state.status).to eq 'completed'
+  end
+  
   it "should not allow an invalid state to be set" do
-    expect{LyberCore::Robot::ReturnState.new('bogus')}.to raise_error(RuntimeError,'invalid return state')
+    expect{LyberCore::Robot::ReturnState.new(status: 'bogus')}.to raise_error(RuntimeError,'invalid return state')
   end
     
 end

--- a/spec/lyber_core/robots/return_state_spec.rb
+++ b/spec/lyber_core/robots/return_state_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe LyberCore::Robot::ReturnState do
+  
+  it "should set the completed state by default" do
+    return_state=LyberCore::Robot::ReturnState.new
+    expect(return_state.status).to eq 'completed'
+  end
+
+  it "should allow other return states to be set" do
+    return_state=LyberCore::Robot::ReturnState.new('completed')
+    expect(return_state.status).to eq 'completed'
+    return_state=LyberCore::Robot::ReturnState.new
+    return_state.status='skipped'
+    expect(return_state.status).to eq 'skipped'
+    return_state=LyberCore::Robot::ReturnState.new('skipped')
+    expect(return_state.status).to eq 'skipped'
+  end
+  
+  it "should not care about the case or if it is symbol" do
+    return_state=LyberCore::Robot::ReturnState.new('COMPLETED')
+    expect(return_state.status).to eq 'completed'
+    return_state=LyberCore::Robot::ReturnState.new(:skipped)
+    expect(return_state.status).to eq 'skipped'
+  end
+
+  it "should not allow an invalid state to be set" do
+    expect{LyberCore::Robot::ReturnState.new('bogus')}.to raise_error(RuntimeError,'invalid return state')
+  end
+    
+end

--- a/spec/lyber_core/robots/robot_spec.rb
+++ b/spec/lyber_core/robots/robot_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require_relative 'test_robot'
+require_relative 'test_robot_with_skip'
 
 describe LyberCore::Robot do
 
@@ -20,6 +21,18 @@ describe LyberCore::Robot do
       expect(logged).to match /work done\!/
     end
 
+    it "updates workflow to 'skipped' if work processes and returns the object with the correct state" do
+      expect(Dor::WorkflowService).to receive(:get_workflow_status).with('dor', druid, wf_name, step_name).and_return('queued')
+      expect(Dor::WorkflowService).to receive(:update_workflow_status).with('dor', druid, wf_name, step_name, 'skipped',
+                                                                              :elapsed => an_instance_of(Float),
+                                                                              :note => Socket.gethostname, :current_status=>"queued")
+      logged = capture_stdout do
+        TestRobotWithSkip.perform druid
+      end
+      expect(logged).to match /#{druid} processing/
+      expect(logged).to match /work done\!/
+    end
+    
     it "updates workflow to 'error' if there was a problem with the work" do
       expect(Dor::WorkflowService).to receive(:get_workflow_status).with('dor', druid, wf_name, step_name).and_return('queued')
       expect(Dor::WorkflowService).to receive(:update_workflow_error_status).with('dor', druid, wf_name, step_name, /work error/, :error_text => Socket.gethostname)

--- a/spec/lyber_core/robots/test_robot_with_constant_state.rb
+++ b/spec/lyber_core/robots/test_robot_with_constant_state.rb
@@ -1,6 +1,6 @@
 require 'lyber_core'
 
-class TestRobotWithSkip
+class TestRobotWithConstantState
   include LyberCore::Robot
 
   def initialize
@@ -9,6 +9,6 @@ class TestRobotWithSkip
 
   def perform(druid)
     LyberCore::Log.info 'work done!'
-    return LyberCore::Robot::ReturnState.new(status: 'skipped')
+    return LyberCore::Robot::ReturnState.SKIPPED
   end
 end

--- a/spec/lyber_core/robots/test_robot_with_note.rb
+++ b/spec/lyber_core/robots/test_robot_with_note.rb
@@ -1,6 +1,6 @@
 require 'lyber_core'
 
-class TestRobotWithSkip
+class TestRobotWithNote
   include LyberCore::Robot
 
   def initialize
@@ -9,6 +9,6 @@ class TestRobotWithSkip
 
   def perform(druid)
     LyberCore::Log.info 'work done!'
-    return LyberCore::Robot::ReturnState.new(status: 'skipped')
+    return LyberCore::Robot::ReturnState.new(note: 'some note to pass back to workflow')
   end
 end

--- a/spec/lyber_core/robots/test_robot_with_note_and_skip.rb
+++ b/spec/lyber_core/robots/test_robot_with_note_and_skip.rb
@@ -1,6 +1,6 @@
 require 'lyber_core'
 
-class TestRobotWithSkip
+class TestRobotWithNoteAndSkip
   include LyberCore::Robot
 
   def initialize
@@ -9,6 +9,6 @@ class TestRobotWithSkip
 
   def perform(druid)
     LyberCore::Log.info 'work done!'
-    return LyberCore::Robot::ReturnState.new(status: 'skipped')
+    return LyberCore::Robot::ReturnState.new(status: 'skipped', note: 'some note to pass back to workflow')
   end
 end

--- a/spec/lyber_core/robots/test_robot_with_skip.rb
+++ b/spec/lyber_core/robots/test_robot_with_skip.rb
@@ -1,0 +1,14 @@
+require 'lyber_core'
+
+class TestRobotWithSkip
+  include LyberCore::Robot
+
+  def initialize
+    super('dor', 'testWF', 'test-step')
+  end
+
+  def perform(druid)
+    LyberCore::Log.info 'work done!'
+    return LyberCore::Robot::ReturnState.new('skipped')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,23 @@
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'simplecov'
+require 'coveralls'
+Coveralls.wear!
 
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+])
+SimpleCov.start do
+  add_filter 'spec/'
+end
 require 'bundler/setup'
 require 'rspec'
 require 'lyber_core'
 require 'dor-workflow-service'
 
 RSpec.configure do |config|
-
+  config.order = 'random'
 end
 
 module Kernel


### PR DESCRIPTION
Create a new object which a robot can optionally return when perform is finished.  This object defines the final workflow state that is set by lyber-core (allowed values are "skipped" or "completed").  

```return LyberCore::Robot::ReturnState.new('skipped')```

For backwards compatibility, if you do not return an object of the expected type upon completion of the perform method, the end state will continue to be "completed".

Also add coveralls and set the test order to random.
