### PR TITLE
Add waiting as another valid robot return state

### DIFF
--- a/lib/lyber_core/return_state.rb
+++ b/lib/lyber_core/return_state.rb
@@ -7,7 +7,7 @@ module LyberCore
       
       attr_reader :status
       attr_accessor :note
-      ALLOWED_RETURN_STATES = %w{completed skipped}
+      ALLOWED_RETURN_STATES = %w{completed skipped waiting}
       DEFAULT_RETURN_STATE  = 'completed'
       
       def self.SKIPPED
@@ -17,7 +17,11 @@ module LyberCore
       def self.COMPLETED
         self.new(status: 'completed')
       end
-      
+
+      def self.WAITING
+        self.new(status: 'waiting')
+      end
+
       def initialize(params = {})
         self.status = params[:status] || DEFAULT_RETURN_STATE
         self.note = params[:note] || ""

--- a/spec/lyber_core/robots/return_state_spec.rb
+++ b/spec/lyber_core/robots/return_state_spec.rb
@@ -41,6 +41,8 @@ describe LyberCore::Robot::ReturnState do
     expect(return_state.status).to eq 'skipped'
     return_state=LyberCore::Robot::ReturnState.COMPLETED
     expect(return_state.status).to eq 'completed'
+    return_state=LyberCore::Robot::ReturnState.WAITING
+    expect(return_state.status).to eq 'waiting'
   end
   
   it "should not allow an invalid state to be set" do


### PR DESCRIPTION
The ETD `check-marc` robot has a use-case for reseting the state of an object in order to try again later. 