### PR TITLE
lib/lyber_core/robot.rb - require activesupport correctly

### DIFF
--- a/lib/lyber_core/robot.rb
+++ b/lib/lyber_core/robot.rb
@@ -1,4 +1,6 @@
 require 'benchmark'
+require 'active_support'
+require 'active_support/core_ext'
 require 'active_support/core_ext/string/inflections' # camelcase
 
 module LyberCore

--- a/lyber-core.gemspec
+++ b/lyber-core.gemspec
@@ -4,7 +4,7 @@ $:.unshift lib unless $:.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = "lyber-core"
-  s.version     = "4.1.1"
+  s.version     = "4.1.2"
   s.licenses    = ['Apache-2.0']
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Alpana Pande","Bess Sadler","Chris Fitzpatrick","Douglas Kim","Richard Anderson","Willy Mene","Michael Klein", "Darren Weber","Peter Mangiafico"]


### PR DESCRIPTION
- see https://github.com/rails/rails/issues/14664

I ran into exactly that bug when trying to upgrade the master branch of sdr-preservation-core to a more recent version of lyber-core, e.g.
- https://travis-ci.org/sul-dlss/sdr-preservation-core/builds/246035390

I may need to apply this patch to earlier releases of lyber-core (e.g. 3.x version).