### PR TITLE
Bundler expects there to be a ruby file with the same name as the gem

### DIFF
--- a/lib/lyber-core.rb
+++ b/lib/lyber-core.rb
@@ -1,0 +1,1 @@
+require 'lyber_core'


### PR DESCRIPTION
This allows us to load lyber-core without having a specific require 'lyber_core'