### PR TITLE
Allow robot to return noop, which will not update workflow step.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,3 +15,7 @@ Layout/AccessModifierIndentation:
 # Configuration parameters: AllowURI, URISchemes.
 Layout/LineLength:
   Max: 177
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'

--- a/lib/lyber_core/log.rb
+++ b/lib/lyber_core/log.rb
@@ -92,14 +92,14 @@ module LyberCore
       @@log.add(Logger::DEBUG) { msg }
     end
 
-    def Log.exception(e)
-      msg = Log.exception_message(e)
+    def Log.exception(exc)
+      msg = Log.exception_message(exc)
       Log.error(msg)
     end
 
-    def Log.exception_message(e)
-      msg = e.inspect.split($/).join('; ') + "\n"
-      msg << e.backtrace.join("\n") if e.backtrace
+    def Log.exception_message(exc)
+      msg = exc.inspect.split($/).join('; ') + "\n"
+      msg << exc.backtrace.join("\n") if exc.backtrace
     end
   end
 end

--- a/lib/lyber_core/return_state.rb
+++ b/lib/lyber_core/return_state.rb
@@ -8,7 +8,7 @@ module LyberCore
     class ReturnState
       attr_reader :status
       attr_accessor :note
-      ALLOWED_RETURN_STATES = %w[completed skipped waiting].freeze
+      ALLOWED_RETURN_STATES = %w[completed skipped waiting noop].freeze
       DEFAULT_RETURN_STATE  = 'completed'
 
       def initialize(params = {})

--- a/spec/lyber_core/robots/robot_spec.rb
+++ b/spec/lyber_core/robots/robot_spec.rb
@@ -162,4 +162,19 @@ RSpec.describe 'robot "bases"' do
       expect(logged).to match /Item druid\:.* is not queued.*completed/m
     end
   end
+  context 'when ReturnState is noop' do
+    let(:test_robot) do
+      Class.new do
+        include LyberCore::Robot
+
+        def perform(_druid)
+          LyberCore::Log.info('work done!') && LyberCore::Robot::ReturnState.new(status: 'noop')
+        end
+      end
+    end
+
+    it 'does not update workflow' do
+      expect(workflow_client).not_to have_received(:update_status)
+    end
+  end
 end


### PR DESCRIPTION
Also, cleaned up some unrelated rubocop and tweaked a little logging.

refs https://github.com/sul-dlss/common-accessioning/issues/575