### PR TITLE
get workflow_name VALUE into logging

### DIFF
--- a/lib/lyber_core/robot.rb
+++ b/lib/lyber_core/robot.rb
@@ -40,8 +40,8 @@ module LyberCore
     def work(druid, context)
       Honeybadger.context(druid: druid, process: process, workflow_name: workflow_name) if defined? Honeybadger
       workflow = workflow(druid)
-      LyberCore::Log.set_logfile($stdout) # let process manager(bluepill) handle logging
-      LyberCore::Log.info "#{druid} processing #{process} (#workflow_name)"
+      LyberCore::Log.set_logfile($stdout) # let process manager handle logging
+      LyberCore::Log.info "#{druid} processing #{process} (#{workflow_name})"
       return if check_queued_status && !item_queued?(druid)
 
       # this is the default note to pass back to workflow service,


### PR DESCRIPTION
## Why was this change made?

because I don't think `#workflow_name` was the desired output in the robot logs:

```
 INFO [2020-03-27 17:15:14] (29700)  :: druid:vy293gd2473 processing publish (#workflow_name)
 INFO [2020-03-27 17:15:15] (29700)  :: Finished druid:vy293gd2473 in 0.7900s
 INFO [2020-03-27 17:15:15] (29703)  :: druid:vy293gd2473 processing provenance-metadata (#workflow_name)
 INFO [2020-03-27 17:15:16] (29703)  :: Finished druid:vy293gd2473 in 0.2956s
 INFO [2020-03-27 17:15:16] (29705)  :: druid:vy293gd2473 processing sdr-ingest-transfer (#workflow_name)
```

## Was the usage documentation (e.g. wiki, README) updated?

na