### PR TITLE
Check-in Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,3 @@ workflow_service.log*
 .ruby-version
 .ruby-gemset
 *.gem
-Gemfile.lock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,89 @@
+PATH
+  remote: .
+  specs:
+    lyber-core (6.1.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    coveralls (0.8.23)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.16.1)
+      term-ansicolor (~> 1.3)
+      thor (>= 0.19.4, < 2.0)
+      tins (~> 1.6)
+    diff-lcs (1.5.0)
+    docile (1.4.0)
+    json (2.6.2)
+    parallel (1.22.1)
+    parser (3.1.2.0)
+      ast (~> 2.4.1)
+    psych (4.0.4)
+      stringio
+    rainbow (3.1.1)
+    rake (13.0.6)
+    rdoc (6.4.0)
+      psych (>= 4.0.0)
+    regexp_parser (2.5.0)
+    rexml (3.2.5)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
+    rubocop (0.93.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.5)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8)
+      rexml
+      rubocop-ast (>= 0.6.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (1.18.0)
+      parser (>= 3.1.1.0)
+    rubocop-rspec (1.44.1)
+      rubocop (~> 0.87)
+      rubocop-ast (>= 0.7.1)
+    ruby-progressbar (1.11.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    stringio (3.0.2)
+    sync (0.5.0)
+    term-ansicolor (1.7.1)
+      tins (~> 1.0)
+    thor (1.2.1)
+    tins (1.31.1)
+      sync
+    unicode-display_width (1.8.0)
+    webrick (1.7.0)
+    yard (0.9.28)
+      webrick (~> 1.7.0)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  coveralls
+  lyber-core!
+  rake (>= 0.8.7)
+  rdoc
+  rspec (~> 3.0)
+  rubocop
+  rubocop-rspec (~> 1.24)
+  yard
+
+BUNDLED WITH
+   2.3.16


### PR DESCRIPTION
## Why was this change made? 🤔

Because the bundler docs recommend this: https://bundler.io/v2.2/guides/faq.html#using-gemfiles-inside-gems

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that use robots*** (e.g accessioning, create_preassembly_image_spec for preservation) and/or test in [stage|qa] environment (was_robot_suite, gis_robot_suite), in addition to specs. ⚡
