### PR TITLE
Add missing require for socket

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/lyber_core/robot.rb
+++ b/lib/lyber_core/robot.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'benchmark'
+require 'socket'
 
 module LyberCore
   module Robot


### PR DESCRIPTION
## Why was this change made? 🤔
This is not required by default in Ruby 3.


## How was this change tested? 🤨
ci