### PR TITLE
Make the dependency on activesupport explicit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,18 @@ PATH
   remote: .
   specs:
     lyber-core (6.1.1)
+      activesupport
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (7.0.3.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
     ast (2.4.2)
+    concurrent-ruby (1.1.10)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -15,7 +22,10 @@ GEM
       tins (~> 1.6)
     diff-lcs (1.5.0)
     docile (1.4.0)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
     json (2.6.2)
+    minitest (5.16.2)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -67,6 +77,8 @@ GEM
     thor (1.2.1)
     tins (1.31.1)
       sync
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
     webrick (1.7.0)
     yard (0.9.28)

--- a/lib/lyber_core/robot.rb
+++ b/lib/lyber_core/robot.rb
@@ -2,6 +2,8 @@
 
 require 'benchmark'
 require 'socket'
+require 'active_support'
+require 'active_support/core_ext/object/blank' # String#blank?
 
 module LyberCore
   module Robot

--- a/lyber-core.gemspec
+++ b/lyber-core.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>=3.0'
   s.required_rubygems_version = '>= 1.3.6'
 
+  s.add_dependency 'activesupport'
+
   # Bundler will install these gems too if you've checked out lyber-core source from git and run 'bundle install'
   # It will not add these as dependencies if you require lyber-core for other projects
   s.add_development_dependency 'coveralls'


### PR DESCRIPTION
## Why was this change made? 🤔

So that we can remove coveralls.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that use robots*** (e.g accessioning, create_preassembly_image_spec for preservation) and/or test in [stage|qa] environment (was_robot_suite, gis_robot_suite), in addition to specs. ⚡


