### PR TITLE
allow skip queue check for run_robot

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,6 +217,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-linux

--- a/lib/lyber_core/robot.rb
+++ b/lib/lyber_core/robot.rb
@@ -8,12 +8,14 @@ module LyberCore
     sidekiq_options retry: 0
 
     attr_reader :workflow_name, :process, :druid
+    attr_accessor :check_queued_status
 
     delegate :lane_id, to: :workflow
 
-    def initialize(workflow_name, process)
+    def initialize(workflow_name, process, check_queued_status: true)
       @workflow_name = workflow_name
       @process = process
+      @check_queued_status = check_queued_status
     end
 
     def workflow_service
@@ -108,6 +110,8 @@ module LyberCore
     end
 
     def check_item_queued?
+      return true unless check_queued_status
+
       return true if /queued/i.match?(workflow.status)
 
       msg = "Item #{druid} is not queued for #{process} (#{workflow_name}), " \


### PR DESCRIPTION
## Why was this change made? 🤔

Add back in the ability to skip the `queued` state check so that `run_robot` script can work in the robot suites.  See https://github.com/sul-dlss/gis-robot-suite/pull/747

This ability was removed about 1 year ago (along with a bigger refactor) here: https://github.com/sul-dlss/lyber-core/commit/628a2c37e2c2178423e082dbe60a5453eb959b9d

## How was this change tested? 🤨

New spec

