### PR TITLE
add workflow context knowledge to lyber-core gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       activesupport
       config
       dor-services-client (~> 14.0)
-      dor-workflow-client
+      dor-workflow-client (>= 7.4)
       druid-tools
       honeybadger
       sidekiq (~> 7.0)
@@ -62,7 +62,7 @@ GEM
       faraday (~> 2.0)
       faraday-retry
       zeitwerk (~> 2.1)
-    dor-workflow-client (7.3.0)
+    dor-workflow-client (7.4.0)
       activesupport (>= 3.2.1, < 8)
       deprecation (>= 0.99.0)
       faraday (~> 2.0)

--- a/lib/lyber_core/workflow.rb
+++ b/lib/lyber_core/workflow.rb
@@ -36,6 +36,13 @@ module LyberCore
                                            error_text: error_text)
     end
 
+    # @return [Hash] any workflow context associated with the workflow
+    def context
+      @context ||= workflow_service.process(pid: druid,
+                                            workflow_name: workflow_name,
+                                            process: process).context
+    end
+
     def status
       @status ||= workflow_service.workflow_status(druid: druid,
                                                    workflow: workflow_name,

--- a/lyber-core.gemspec
+++ b/lyber-core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport'
   s.add_dependency 'config'
   s.add_dependency 'dor-services-client', '~> 14.0'
-  s.add_dependency 'dor-workflow-client'
+  s.add_dependency 'dor-workflow-client', '>= 7.4' # 7.4.0 has the ability to set and return workflow context
   s.add_dependency 'druid-tools'
   s.add_dependency 'honeybadger'
   s.add_dependency 'sidekiq', '~> 7.0'

--- a/spec/lyber_core/workflow_spec.rb
+++ b/spec/lyber_core/workflow_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+describe LyberCore::Workflow do
+  let(:workflow) do
+    described_class.new(workflow_service: workflow_client, druid: 'druid:123', workflow_name: 'workflow',
+                        process: 'process')
+  end
+  let(:workflow_client) { instance_double(Dor::Workflow::Client, process: workflow_process, workflow_status: status) }
+  let(:workflow_process) { instance_double(Dor::Workflow::Response::Process, lane_id: lane_id, context: context) }
+  let(:lane_id) { 'lane1' }
+  let(:context) { { 'foo' => 'bar' } }
+  let(:note) { 'note' }
+  let(:status) { 'waiting' }
+
+  before do
+    allow(workflow_client).to receive(:process).and_return(workflow_process)
+    allow(workflow_client).to receive(:update_status)
+    allow(workflow_client).to receive(:update_error_status)
+  end
+
+  describe '#start!' do
+    it 'updates the status to started' do
+      workflow.start!(note)
+      expect(workflow_client).to have_received(:update_status).with(druid: 'druid:123', workflow: 'workflow',
+                                                                    process: 'process', status: 'started',
+                                                                    elapsed: 1.0, note: note)
+    end
+  end
+
+  describe '#complete!' do
+    let(:complete_status) { 'completed' }
+    let(:elapsed) { 3.0 }
+
+    it 'updates the status to provided status' do
+      workflow.complete!(complete_status, elapsed, note)
+      expect(workflow_client).to have_received(:update_status).with(druid: 'druid:123', workflow: 'workflow',
+                                                                    process: 'process', status: complete_status,
+                                                                    elapsed: 3.0, note: note)
+    end
+  end
+
+  describe '#error!' do
+    let(:error_msg) { 'Doh' }
+    let(:error_text) { 'Whelp, that was bad.' }
+
+    it 'updates the status to an error' do
+      workflow.error!(error_msg, error_text)
+      expect(workflow_client).to have_received(:update_error_status).with(druid: 'druid:123', workflow: 'workflow',
+                                                                          process: 'process', error_msg: error_msg,
+                                                                          error_text: error_text)
+    end
+  end
+
+  describe '#context' do
+    it 'returns the context hash' do
+      expect(workflow.context).to eq(context)
+    end
+  end
+
+  describe '#lane_id' do
+    it 'returns the lane_id' do
+      expect(workflow.lane_id).to eq(lane_id)
+    end
+  end
+
+  describe '#status' do
+    it 'returns the status' do
+      expect(workflow.status).to eq(status)
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #166 -- lyber-core can now return workflow context, so that we can make use of this from the new ocrWF robots in a manner consistent to how status is accessed

## How was this change tested? 🤨

- New specs (including adding missing specs for the other methods in the class I touched)
- Localhost via the common-accessioning console