### PR TITLE
remove unnecessary allow

### DIFF
--- a/spec/lyber_core/workflow_spec.rb
+++ b/spec/lyber_core/workflow_spec.rb
@@ -13,7 +13,6 @@ describe LyberCore::Workflow do
   let(:status) { 'waiting' }
 
   before do
-    allow(workflow_client).to receive(:process).and_return(workflow_process)
     allow(workflow_client).to receive(:update_status)
     allow(workflow_client).to receive(:update_error_status)
   end


### PR DESCRIPTION
## Why was this change made? 🤔

covered in the setup of the `let` var on which the removed `allow` is called

follow on from #167 

## How was this change tested? 🤨

unit tests

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that use robots*** (e.g accessioning, create_preassembly_image_spec for preservation) and/or test in [stage|qa] environment (was_robot_suite, gis_robot_suite), in addition to specs. ⚡


