### PR TITLE
Rubocop rule updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -253,13 +253,13 @@ FactoryBot/FactoryNameStyle: # new in 2.16
   Enabled: true
 FactoryBot/SyntaxMethods: # new in 2.7
   Enabled: true
-RSpec/Rails/AvoidSetupHook: # new in 2.4
+RSpecRails/AvoidSetupHook: # new in 2.4
   Enabled: true
-RSpec/Rails/HaveHttpStatus: # new in 2.12
+RSpecRails/HaveHttpStatus: # new in 2.12
   Enabled: true
-RSpec/Rails/InferredSpecType: # new in 2.14
+RSpecRails/InferredSpecType: # new in 2.14
   Enabled: true
-RSpec/Rails/MinitestAssertions: # new in 2.17
+RSpecRails/MinitestAssertions: # new in 2.17
   Enabled: true
 Gemspec/DevelopmentDependencies: # new in 1.44
   Enabled: true
@@ -308,5 +308,66 @@ RSpec/RedundantAround: # new in 2.19
   Enabled: true
 RSpec/SkipBlockInsideExample: # new in 2.19
   Enabled: true
-RSpec/Rails/TravelAround: # new in 2.19
+RSpecRails/TravelAround: # new in 2.19
+  Enabled: true
+
+Lint/ItWithoutArgumentsInBlock: # new in 1.59
+  Enabled: true
+Lint/LiteralAssignmentInCondition: # new in 1.58
+  Enabled: true
+Lint/MixedCaseRange: # new in 1.53
+  Enabled: true
+Lint/RedundantRegexpQuantifiers: # new in 1.53
+  Enabled: true
+Style/MapIntoArray: # new in 1.63
+  Enabled: true
+Style/RedundantCurrentDirectoryInPath: # new in 1.53
+  Enabled: true
+Style/RedundantRegexpArgument: # new in 1.53
+  Enabled: true
+Style/ReturnNilInPredicateMethodDefinition: # new in 1.53
+  Enabled: true
+Style/SingleLineDoEndBlock: # new in 1.57
+  Enabled: true
+Style/SuperWithArgsParentheses: # new in 1.58
+  Enabled: true
+Style/YAMLFileRead: # new in 1.53
+  Enabled: true
+Capybara/ClickLinkOrButtonStyle: # new in 2.19
+  Enabled: true
+Capybara/RedundantWithinFind: # new in 2.20
+  Enabled: true
+Capybara/RSpec/HaveSelector: # new in 2.19
+  Enabled: true
+Capybara/RSpec/PredicateMatcher: # new in 2.19
+  Enabled: true
+FactoryBot/ExcessiveCreateList: # new in 2.25
+  Enabled: true
+FactoryBot/IdSequence: # new in 2.24
+  Enabled: true
+RSpecRails/NegationBeValid: # new in 2.23
+  Enabled: true
+RSpec/EmptyMetadata: # new in 2.24
+  Enabled: true
+RSpec/EmptyOutput: # new in 2.29
+  Enabled: true
+RSpec/Eq: # new in 2.24
+  Enabled: true
+RSpec/IsExpectedSpecify: # new in 2.27
+  Enabled: true
+RSpec/MetadataStyle: # new in 2.24
+  Enabled: true
+RSpec/ReceiveMessages: # new in 2.23
+  Enabled: true
+RSpec/RedundantPredicateMatcher: # new in 2.26
+  Enabled: true
+RSpec/RemoveConst: # new in 2.26
+  Enabled: true
+RSpec/RepeatedSubjectCall: # new in 2.27
+  Enabled: true
+RSpec/SpecFilePathFormat: # new in 2.24
+  Enabled: true
+RSpec/SpecFilePathSuffix: # new in 2.24
+  Enabled: true
+RSpec/UndescriptiveLiteralsDescription: # new in 2.29
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.2
   SuggestExtensions: false
   DisplayCopNames: true
   Include:

--- a/lib/lyber_core/robot.rb
+++ b/lib/lyber_core/robot.rb
@@ -19,7 +19,7 @@ module LyberCore
     end
 
     def workflow_service
-      @workflow_service ||= WorkflowClientFactory.build(logger: logger)
+      @workflow_service ||= WorkflowClientFactory.build(logger:)
     end
 
     def object_client
@@ -40,7 +40,7 @@ module LyberCore
     # rubocop:disable Metrics/MethodLength
     def perform(druid)
       @druid = druid
-      Honeybadger.context(druid: druid, process: process, workflow_name: workflow_name)
+      Honeybadger.context(druid:, process:, workflow_name:)
 
       logger.info "#{druid} processing #{process} (#{workflow_name})"
       return unless check_item_queued?
@@ -103,10 +103,10 @@ module LyberCore
     # rubocop:enable Metrics/AbcSize
 
     def workflow
-      @workflow ||= Workflow.new(workflow_service: workflow_service,
-                                 druid: druid,
-                                 workflow_name: workflow_name,
-                                 process: process)
+      @workflow ||= Workflow.new(workflow_service:,
+                                 druid:,
+                                 workflow_name:,
+                                 process:)
     end
 
     def check_item_queued?

--- a/lib/lyber_core/workflow.rb
+++ b/lib/lyber_core/workflow.rb
@@ -11,46 +11,46 @@ module LyberCore
     end
 
     def start!(note)
-      workflow_service.update_status(druid: druid,
+      workflow_service.update_status(druid:,
                                      workflow: workflow_name,
-                                     process: process,
+                                     process:,
                                      status: 'started',
                                      elapsed: 1.0,
-                                     note: note)
+                                     note:)
     end
 
     def complete!(status, elapsed, note)
-      workflow_service.update_status(druid: druid,
+      workflow_service.update_status(druid:,
                                      workflow: workflow_name,
-                                     process: process,
-                                     status: status,
-                                     elapsed: elapsed,
-                                     note: note)
+                                     process:,
+                                     status:,
+                                     elapsed:,
+                                     note:)
     end
 
     def error!(error_msg, error_text)
-      workflow_service.update_error_status(druid: druid,
+      workflow_service.update_error_status(druid:,
                                            workflow: workflow_name,
-                                           process: process,
-                                           error_msg: error_msg,
-                                           error_text: error_text)
+                                           process:,
+                                           error_msg:,
+                                           error_text:)
     end
 
     # @return [Hash] any workflow context associated with the workflow
     def context
       @context ||= workflow_service.process(pid: druid,
-                                            workflow_name: workflow_name,
-                                            process: process).context
+                                            workflow_name:,
+                                            process:).context
     end
 
     def status
-      @status ||= workflow_service.workflow_status(druid: druid,
+      @status ||= workflow_service.workflow_status(druid:,
                                                    workflow: workflow_name,
-                                                   process: process)
+                                                   process:)
     end
 
     def lane_id
-      @lane_id ||= workflow_service.process(pid: druid, workflow_name: workflow_name, process: process).lane_id
+      @lane_id ||= workflow_service.process(pid: druid, workflow_name:, process:).lane_id
     end
 
     private

--- a/lib/lyber_core/workflow_client_factory.rb
+++ b/lib/lyber_core/workflow_client_factory.rb
@@ -4,7 +4,7 @@ module LyberCore
   # Factory for creating a workflow client
   class WorkflowClientFactory
     def self.build(logger:)
-      Dor::Workflow::Client.new(url: Settings.workflow.url, logger: logger, timeout: Settings.workflow.timeout)
+      Dor::Workflow::Client.new(url: Settings.workflow.url, logger:, timeout: Settings.workflow.timeout)
     end
   end
 end

--- a/lyber-core.gemspec
+++ b/lyber-core.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = "Contains classes to make http connections with a client-cert, use Jhove, and call Suri\n" \
                     'Also contains core classes to build robots'
 
-  s.required_ruby_version = '>=3.0'
+  s.required_ruby_version = '>=3.2'
   s.required_rubygems_version = '>= 1.3.6'
 
   s.add_dependency 'activesupport'

--- a/spec/lyber_core/robot_spec.rb
+++ b/spec/lyber_core/robot_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe LyberCore::Robot do
 
   before do
     allow(LyberCore::WorkflowClientFactory).to receive(:build).and_return(workflow_client)
-    allow(workflow_client).to receive(:workflow_status).with(druid: druid, workflow: wf_name,
+    allow(workflow_client).to receive(:workflow_status).with(druid:, workflow: wf_name,
                                                              process: step_name).and_return('queued')
     allow(robot).to receive(:logger).and_return(logger)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
@@ -65,7 +65,7 @@ RSpec.describe LyberCore::Robot do
       expect(Dor::Services::Client).to have_received(:object).with(druid)
       expect(DruidTools::Druid).to have_received(:new).with(druid, '/tmp')
 
-      expect(workflow_client).to have_received(:update_status).with(druid: druid,
+      expect(workflow_client).to have_received(:update_status).with(druid:,
                                                                     workflow: wf_name,
                                                                     process: step_name,
                                                                     status: 'completed',
@@ -92,7 +92,7 @@ RSpec.describe LyberCore::Robot do
       expect(logger).to have_received(:info).with(/#{druid} processing/)
       expect(logger).to have_received(:info).with('work done!')
 
-      expect(workflow_client).to have_received(:update_status).with(druid: druid,
+      expect(workflow_client).to have_received(:update_status).with(druid:,
                                                                     workflow: wf_name,
                                                                     process: step_name,
                                                                     status: 'skipped',
@@ -116,13 +116,13 @@ RSpec.describe LyberCore::Robot do
       expect(logger).to have_received(:info).with(/#{druid} processing/)
       expect(logger).to have_received(:info).with('work done!')
 
-      expect(workflow_client).to have_received(:update_status).with(druid: druid,
+      expect(workflow_client).to have_received(:update_status).with(druid:,
                                                                     workflow: wf_name,
                                                                     process: step_name,
                                                                     status: 'started',
                                                                     elapsed: 1.0,
                                                                     note: Socket.gethostname)
-      expect(workflow_client).to have_received(:update_status).with(druid: druid,
+      expect(workflow_client).to have_received(:update_status).with(druid:,
                                                                     workflow: wf_name,
                                                                     process: step_name,
                                                                     status: 'completed',
@@ -146,7 +146,7 @@ RSpec.describe LyberCore::Robot do
       expect(logger).to have_received(:info).with(/#{druid} processing/)
       expect(logger).to have_received(:info).with('work done!')
 
-      expect(workflow_client).to have_received(:update_status).with(druid: druid,
+      expect(workflow_client).to have_received(:update_status).with(druid:,
                                                                     workflow: wf_name,
                                                                     process: step_name,
                                                                     status: 'skipped',
@@ -167,7 +167,7 @@ RSpec.describe LyberCore::Robot do
     it "updates workflow to 'error' if there was a problem with the work" do
       robot.perform(druid)
       expect(logger).to have_received(:error).with(/work error/)
-      expect(workflow_client).to have_received(:update_error_status).with(druid: druid,
+      expect(workflow_client).to have_received(:update_error_status).with(druid:,
                                                                           workflow: wf_name,
                                                                           process: step_name,
                                                                           error_msg: /work error/,
@@ -177,7 +177,7 @@ RSpec.describe LyberCore::Robot do
 
   context 'when workflow status is not queued' do
     before do
-      allow(workflow_client).to receive(:workflow_status).with(druid: druid, workflow: wf_name,
+      allow(workflow_client).to receive(:workflow_status).with(druid:, workflow: wf_name,
                                                                process: step_name).and_return('completed')
     end
 
@@ -199,7 +199,7 @@ RSpec.describe LyberCore::Robot do
       expect(logger).to have_received(:info).with('work done!')
       expect(Dor::Services::Client).to have_received(:object).with(druid)
 
-      expect(workflow_client).to have_received(:update_status).with(druid: druid,
+      expect(workflow_client).to have_received(:update_status).with(druid:,
                                                                     workflow: wf_name,
                                                                     process: step_name,
                                                                     status: 'completed',

--- a/spec/lyber_core/workflow_spec.rb
+++ b/spec/lyber_core/workflow_spec.rb
@@ -6,7 +6,7 @@ describe LyberCore::Workflow do
                         process: 'process')
   end
   let(:workflow_client) { instance_double(Dor::Workflow::Client, process: workflow_process, workflow_status: status) }
-  let(:workflow_process) { instance_double(Dor::Workflow::Response::Process, lane_id: lane_id, context: context) }
+  let(:workflow_process) { instance_double(Dor::Workflow::Response::Process, lane_id:, context:) }
   let(:lane_id) { 'lane1' }
   let(:context) { { 'foo' => 'bar' } }
   let(:note) { 'note' }
@@ -23,7 +23,7 @@ describe LyberCore::Workflow do
       workflow.start!(note)
       expect(workflow_client).to have_received(:update_status).with(druid: 'druid:123', workflow: 'workflow',
                                                                     process: 'process', status: 'started',
-                                                                    elapsed: 1.0, note: note)
+                                                                    elapsed: 1.0, note:)
     end
   end
 
@@ -35,7 +35,7 @@ describe LyberCore::Workflow do
       workflow.complete!(complete_status, elapsed, note)
       expect(workflow_client).to have_received(:update_status).with(druid: 'druid:123', workflow: 'workflow',
                                                                     process: 'process', status: complete_status,
-                                                                    elapsed: 3.0, note: note)
+                                                                    elapsed: 3.0, note:)
     end
   end
 
@@ -46,8 +46,8 @@ describe LyberCore::Workflow do
     it 'updates the status to an error' do
       workflow.error!(error_msg, error_text)
       expect(workflow_client).to have_received(:update_error_status).with(druid: 'druid:123', workflow: 'workflow',
-                                                                          process: 'process', error_msg: error_msg,
-                                                                          error_text: error_text)
+                                                                          process: 'process', error_msg:,
+                                                                          error_text:)
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

* rubocop config: update deprecated rule names, add missing rules from newer versions
* expect consumers to use ruby 3.2.  i checked, all the robot deployments in all envs (prod, stage, qa) are running on ruby 3.2.2 at present.
  * update rubocop config to use ruby 3.2 parser
  * auto-correct to newer more concise syntax for symbol hash keys/parameter passing

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that use robots*** (e.g accessioning, create_preassembly_image_spec for preservation) and/or test in [stage|qa] environment (was_robot_suite, gis_robot_suite), in addition to specs. ⚡


