### PR TITLE
Bump version to 7.5.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lyber-core (7.4.2)
+    lyber-core (7.5.0)
       activesupport
       config
       dor-services-client (~> 14.0)

--- a/lib/lyber_core/version.rb
+++ b/lib/lyber_core/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LyberCore
-  VERSION = '7.4.2'
+  VERSION = '7.5.0'
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Version bump.  Normally commit straight to master but just double-checking that a minor version is appropriate for new workflow context checking that was added.