### PR TITLE
bump dsa-client version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     lyber-core (7.5.0)
       activesupport
       config
-      dor-services-client (~> 14.0)
+      dor-services-client (~> 15.0)
       dor-workflow-client (>= 7.4)
       druid-tools
       honeybadger
@@ -45,6 +45,7 @@ GEM
       super_diff
       thor
       zeitwerk (~> 2.1)
+    commonmarker (1.1.5-arm64-darwin)
     commonmarker (1.1.5-x86_64-darwin)
     commonmarker (1.1.5-x86_64-linux)
     concurrent-ruby (1.3.4)
@@ -57,7 +58,7 @@ GEM
       activesupport
     diff-lcs (1.5.1)
     docile (1.4.1)
-    dor-services-client (14.21.0)
+    dor-services-client (15.0.0)
       activesupport (>= 4.2, < 8)
       cocina-models (~> 0.99.0)
       deprecation
@@ -119,6 +120,8 @@ GEM
     multi_json (1.15.0)
     net-http (0.4.1)
       uri
+    nokogiri (1.16.7-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.7-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
@@ -201,6 +204,7 @@ GEM
     zeitwerk (2.6.18)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-19
   x86_64-darwin-21
   x86_64-darwin-22

--- a/lyber-core.gemspec
+++ b/lyber-core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport'
   s.add_dependency 'config'
-  s.add_dependency 'dor-services-client', '~> 14.0'
+  s.add_dependency 'dor-services-client', '~> 15.0'
   s.add_dependency 'dor-workflow-client', '>= 7.4' # 7.4.0 has the ability to set and return workflow context
   s.add_dependency 'druid-tools'
   s.add_dependency 'honeybadger'


### PR DESCRIPTION
## Why was this change made? 🤔

DSA client v15 (https://github.com/sul-dlss/dor-services-client/pull/472) removed an endpoint that is also removed from DSA.  Update lyber-core to use it so we can update common-accessioning (which is a consumer of lyber-core).

We need this to bump the dsa-client gem in https://github.com/sul-dlss/common-accessioning/pull/1380, since dsa-client is a dependency of lyber-core too (and is currently pinned to v14)

## How was this change tested? 🤨

Spec