### PR TITLE
Unpin and update sidekiq.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       dor-services-client
       druid-tools
       honeybadger
-      sidekiq (~> 7.0)
+      sidekiq
       zeitwerk
 
 GEM
@@ -181,12 +181,12 @@ GEM
       rubocop-rspec (~> 3.5)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
-    sidekiq (7.3.9)
-      base64
-      connection_pool (>= 2.3.0)
-      logger
-      rack (>= 2.2.4)
-      redis-client (>= 0.22.2)
+    sidekiq (8.0.7)
+      connection_pool (>= 2.5.0)
+      json (>= 2.9.0)
+      logger (>= 1.6.2)
+      rack (>= 3.1.0)
+      redis-client (>= 0.23.2)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)

--- a/lyber-core.gemspec
+++ b/lyber-core.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'dor-services-client'
   s.add_dependency 'druid-tools'
   s.add_dependency 'honeybadger'
-  s.add_dependency 'sidekiq', '~> 7.0'
+  s.add_dependency 'sidekiq'
   s.add_dependency 'zeitwerk'
 
   # Bundler will install these gems too if you've checked out lyber-core source from git and run 'bundle install'


### PR DESCRIPTION
## Why was this change made? 🤔
So that the sidekiqs can all be updated.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that use robots*** (e.g accessioning, create_preassembly_image_spec for preservation) and/or test in [stage|qa] environment (was_robot_suite, gis_robot_suite), in addition to specs. ⚡


