### PR TITLE
allow queued version to be above current version

### DIFF
--- a/lib/lyber_core/robot.rb
+++ b/lib/lyber_core/robot.rb
@@ -121,12 +121,12 @@ module LyberCore
       @workflow ||= Workflow.new(object_client:, workflow_name:, process:, version:)
     end
 
-    # @return [Boolean] true if a version was provided and it no longer matches the object's current version,
+    # @return [Boolean] true if a version was provided and it is lower than the object's current version,
     #   meaning a newer version has superseded the one this job was queued for
     def superseded_version?
       return false if version.nil?
 
-      cocina_object.version.to_i != version.to_i
+      version.to_i < cocina_object.version.to_i
     end
 
     def skip_for_superseded_version!

--- a/spec/lyber_core/robot_spec.rb
+++ b/spec/lyber_core/robot_spec.rb
@@ -243,4 +243,21 @@ RSpec.describe LyberCore::Robot do
       expect(workflow_process).not_to have_received(:update).with(hash_including(status: 'started'))
     end
   end
+
+  context 'when the provided version is above the current version (happens with OCR and speech to text workflows)' do
+    let(:cocina_version) { 1 }
+
+    it 'performs normally' do
+      robot.perform(druid, 2)
+      expect(Tester).to have_received(:bare_druid)
+      expect(logger).to have_received(:info).with(/#{druid} processing/)
+      expect(logger).to have_received(:info).with('work done!')
+      expect(Dor::Services::Client).to have_received(:object).with(druid)
+
+      expect(workflow_process).to have_received(:update).with(status: 'completed',
+                                                              elapsed: Float,
+                                                              note: Socket.gethostname,
+                                                              version: 2)
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

The version aware robot skipping logic should only happen when you try to queue a step for a version that is **below** the current object version, not above.  We want to be able to queue a step for a new version of an object, like what happens in ocrWF and speechToTextWF in the first step of those workflows (which opens the new version).

`accessionWF:end-accession` creates the new workflow for the next version of the object about to be opened:
- https://github.com/sul-dlss/common-accessioning/blob/main/lib/robots/dor_repo/accession/end_accession.rb#L35-L53

and then it is opened:
- https://github.com/sul-dlss/common-accessioning/blob/main/lib/robots/dor_repo/speech_to_text/start_stt.rb#L16
- https://github.com/sul-dlss/common-accessioning/blob/main/lib/robots/dor_repo/ocr/start_ocr.rb#L16 

Current logic causes failures like this: https://argo-stage.stanford.edu/view/druid:wc345db4658

`Note: Item druid:wc345db4658 is queued for version 2 but the current object version is 1. Skipping start-ocr (ocrWF).`
 
## How was this change tested? 🤨

New spec


