### PR TITLE
Fix skipping logic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     bigdecimal (4.1.2)
     byebug (13.0.0)
       reline (>= 0.6.0)
-    cocina-models (0.126.0)
+    cocina-models (0.127.0)
       activesupport
       cocina_display
       deprecation
@@ -64,9 +64,9 @@ GEM
       activesupport
     diff-lcs (1.6.2)
     docile (1.4.1)
-    dor-services-client (15.60.0)
+    dor-services-client (15.62.0)
       activesupport (>= 7.0.0)
-      cocina-models (~> 0.126.0)
+      cocina-models (~> 0.127.0)
       deprecation
       faraday (~> 2.0)
       faraday-retry
@@ -122,11 +122,11 @@ GEM
     iso8601 (0.13.0)
     janeway-jsonpath (1.0.0)
     json (2.20.0)
-    jsonschema_rs (0.46.10-arm64-darwin)
+    jsonschema_rs (0.47.0-arm64-darwin)
       bigdecimal (>= 3.1, < 5)
-    jsonschema_rs (0.46.10-x86_64-darwin)
+    jsonschema_rs (0.47.0-x86_64-darwin)
       bigdecimal (>= 3.1, < 5)
-    jsonschema_rs (0.46.10-x86_64-linux)
+    jsonschema_rs (0.47.0-x86_64-linux)
       bigdecimal (>= 3.1, < 5)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)

--- a/lib/lyber_core/robot.rb
+++ b/lib/lyber_core/robot.rb
@@ -128,6 +128,8 @@ module LyberCore
             'but that is not the active version. Skipping.'
       logger.warn(msg)
       workflow.skip!(msg)
+
+      true
     end
 
     def check_item_queued_or_retry? # rubocop:disable Metrics/AbcSize

--- a/lib/lyber_core/robot.rb
+++ b/lib/lyber_core/robot.rb
@@ -121,12 +121,12 @@ module LyberCore
       @workflow ||= Workflow.new(object_client:, workflow_name:, process:, version:)
     end
 
-    # @return [Boolean] true if a version was provided and it no longer matches the object's current version,
+    # @return [Boolean] true if a version was provided and it is lower than the object's current version,
     #   meaning a newer version has superseded the one this job was queued for
     def superseded_version?
       return false if version.nil?
 
-      cocina_object.version.to_i != version.to_i
+      version.to_i < cocina_object.version.to_i
     end
 
     def skip_for_superseded_version!

--- a/lib/lyber_core/robot.rb
+++ b/lib/lyber_core/robot.rb
@@ -58,7 +58,7 @@ module LyberCore
       Honeybadger.context(druid:, process:, workflow_name:)
 
       logger.info "#{druid} processing #{process} (#{workflow_name})"
-      return skip_for_superseded_version! if superseded_version?
+      return if skip_for_inactive_version?
       return unless check_item_queued_or_retry?
 
       # this is the default note to pass back to workflow service,
@@ -121,15 +121,9 @@ module LyberCore
       @workflow ||= Workflow.new(object_client:, workflow_name:, process:, version:)
     end
 
-    # @return [Boolean] true if a version was provided and it is not the active version of the workflow,
-    #   meaning a newer version has superseded the one this job was queued for
-    def superseded_version?
-      return false if version.nil?
+    def skip_for_inactive_version?
+      return false if version.nil? || workflow.active_version?
 
-      !workflow.active_version?
-    end
-
-    def skip_for_superseded_version!
       msg = "Item #{druid} is queued for version #{version} of #{process} (#{workflow_name}), " \
             'but that is not the active version. Skipping.'
       logger.warn(msg)

--- a/lib/lyber_core/robot.rb
+++ b/lib/lyber_core/robot.rb
@@ -52,10 +52,10 @@ module LyberCore
     # Calls the #perform_work method, then sets workflow to 'completed' or 'error' depending on success
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/MethodLength
-    def perform(druid, version = nil)
+    def perform(druid, version)
       @druid = druid
       @version = version
-      Honeybadger.context(druid:, process:, workflow_name:)
+      Honeybadger.context(druid:, process:, workflow_name:, version:)
 
       logger.info "#{druid} processing #{process} (#{workflow_name})"
       return if skip_for_inactive_version?
@@ -122,7 +122,7 @@ module LyberCore
     end
 
     def skip_for_inactive_version?
-      return false if version.nil? || workflow.active_version?
+      return false if workflow.active_version?
 
       msg = "Item #{druid} is queued for version #{version} of #{process} (#{workflow_name}), " \
             'but that is not the active version. Skipping.'

--- a/lib/lyber_core/robot.rb
+++ b/lib/lyber_core/robot.rb
@@ -121,17 +121,17 @@ module LyberCore
       @workflow ||= Workflow.new(object_client:, workflow_name:, process:, version:)
     end
 
-    # @return [Boolean] true if a version was provided and it is lower than the object's current version,
+    # @return [Boolean] true if a version was provided and it is not the active version of the workflow,
     #   meaning a newer version has superseded the one this job was queued for
     def superseded_version?
       return false if version.nil?
 
-      version.to_i < cocina_object.version.to_i
+      !workflow.active_version?
     end
 
     def skip_for_superseded_version!
-      msg = "Item #{druid} is queued for version #{version} but the current object version is " \
-            "#{cocina_object.version}. Skipping #{process} (#{workflow_name})."
+      msg = "Item #{druid} is queued for version #{version} of #{process} (#{workflow_name}), " \
+            'but that is not the active version. Skipping.'
       logger.warn(msg)
       workflow.skip!(msg)
     end

--- a/lib/lyber_core/workflow.rb
+++ b/lib/lyber_core/workflow.rb
@@ -30,6 +30,11 @@ module LyberCore
       @process_response ||= workflow_response.process_for_recent_version(name: process)
     end
 
+    # @return [Boolean] true if this workflow step is for the active version of the workflow
+    def active_version?
+      workflow_response.process_for(name: process, version:).active_version?
+    end
+
     def start!(note)
       workflow_process.update(status: 'started', elapsed: 1.0, note:, version:)
     end

--- a/spec/lyber_core/robot_spec.rb
+++ b/spec/lyber_core/robot_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe LyberCore::Robot do
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_object) }
   let(:cocina_object) { instance_double(Cocina::Models::DRO, version: cocina_version) }
   let(:cocina_version) { 2 }
+  let(:version) { 2 }
   let(:druid_object) { instance_double(DruidTools::Druid) }
 
   before do
@@ -92,14 +93,14 @@ RSpec.describe LyberCore::Robot do
     let(:return_state) { LyberCore::ReturnState.new(status: 'skipped') }
 
     it "updates workflow to 'skipped'" do
-      robot.perform(druid)
+      robot.perform(druid, version)
       expect(logger).to have_received(:info).with(/#{druid} processing/)
       expect(logger).to have_received(:info).with('work done!')
 
       expect(workflow_process).to have_received(:update).with(status: 'skipped',
                                                               elapsed: Float,
                                                               note: Socket.gethostname,
-                                                              version: nil)
+                                                              version:)
     end
   end
 
@@ -107,18 +108,18 @@ RSpec.describe LyberCore::Robot do
     let(:return_state) { LyberCore::ReturnState.new(note: 'some note to pass back to workflow') }
 
     it "updates workflow to 'completed' and sets a custom note" do
-      robot.perform(druid)
+      robot.perform(druid, version)
       expect(logger).to have_received(:info).with(/#{druid} processing/)
       expect(logger).to have_received(:info).with('work done!')
 
       expect(workflow_process).to have_received(:update).with(status: 'started',
                                                               elapsed: 1.0,
                                                               note: Socket.gethostname,
-                                                              version: nil)
+                                                              version:)
       expect(workflow_process).to have_received(:update).with(status: 'completed',
                                                               elapsed: Float,
                                                               note: 'some note to pass back to workflow',
-                                                              version: nil)
+                                                              version:)
     end
   end
 
@@ -126,14 +127,14 @@ RSpec.describe LyberCore::Robot do
     let(:return_state) { LyberCore::ReturnState.new(status: 'skipped', note: 'some note to pass back to workflow') }
 
     it "updates workflow to 'skipped' and sets a custom note" do
-      robot.perform(druid)
+      robot.perform(druid, version)
       expect(logger).to have_received(:info).with(/#{druid} processing/)
       expect(logger).to have_received(:info).with('work done!')
 
       expect(workflow_process).to have_received(:update).with(status: 'skipped',
                                                               elapsed: Float,
                                                               note: 'some note to pass back to workflow',
-                                                              version: nil)
+                                                              version:)
     end
   end
 
@@ -141,11 +142,11 @@ RSpec.describe LyberCore::Robot do
     let(:exception) { StandardError.new('work error') }
 
     it "updates workflow to 'error'" do
-      robot.perform(druid)
+      robot.perform(druid, version)
       expect(logger).to have_received(:error).with(/work error/)
       expect(workflow_process).to have_received(:update_error).with(error_msg: /work error/,
                                                                     error_text: Socket.gethostname,
-                                                                    version: nil)
+                                                                    version:)
     end
   end
 
@@ -153,12 +154,12 @@ RSpec.describe LyberCore::Robot do
     let(:exception) { NotImplementedError.new('retriable work error') }
 
     it "updates workflow to 'retrying'" do
-      expect { robot.perform(druid) }.to raise_error(NotImplementedError)
+      expect { robot.perform(druid, version) }.to raise_error(NotImplementedError)
       expect(logger).to have_received(:error).with(/retriable work error/)
       expect(workflow_process).to have_received(:update).with(status: 'retrying',
                                                               elapsed: 1.0,
                                                               note: nil,
-                                                              version: nil)
+                                                              version:)
     end
   end
 
@@ -168,7 +169,7 @@ RSpec.describe LyberCore::Robot do
     end
 
     it 'skips the job' do
-      robot.perform(druid)
+      robot.perform(druid, version)
       expect(logger).to have_received(:warn).with(/Item druid:.* is not queued.*completed/m)
     end
   end
@@ -179,7 +180,7 @@ RSpec.describe LyberCore::Robot do
     end
 
     it 'runs the job' do
-      robot.perform(druid)
+      robot.perform(druid, version)
       expect(logger).not_to have_received(:warn).with(/Item druid:.* is not queued.*completed/m)
       expect(logger).to have_received(:info).with(/#{druid} processing/)
       expect(logger).to have_received(:info).with('work done!')
@@ -188,7 +189,7 @@ RSpec.describe LyberCore::Robot do
       expect(workflow_process).to have_received(:update).with(status: 'completed',
                                                               elapsed: Float,
                                                               note: Socket.gethostname,
-                                                              version: nil)
+                                                              version:)
     end
   end
 
@@ -196,7 +197,7 @@ RSpec.describe LyberCore::Robot do
     let(:return_state) { LyberCore::ReturnState.new(status: 'noop') }
 
     it 'only updates workflow for start' do
-      robot.perform(druid)
+      robot.perform(druid, version)
       expect(workflow_process).to have_received(:update).once
     end
   end
@@ -217,19 +218,17 @@ RSpec.describe LyberCore::Robot do
       TestRobot.sidekiq_retries_exhausted_block.call(job, exception)
       expect(workflow_process).to have_received(:update_error).with(error_msg: /work error/,
                                                                     error_text: Socket.gethostname,
-                                                                    version: 2)
+                                                                    version:)
     end
   end
 
   context 'when a version is provided' do
-    let(:cocina_version) { 3 }
-
     it 'updates workflow with the given version' do
-      robot.perform(druid, 3)
+      robot.perform(druid, version)
       expect(workflow_process).to have_received(:update).with(status: 'completed',
                                                               elapsed: Float,
                                                               note: Socket.gethostname,
-                                                              version: 3)
+                                                              version:)
     end
   end
 

--- a/spec/lyber_core/robot_spec.rb
+++ b/spec/lyber_core/robot_spec.rb
@@ -243,4 +243,21 @@ RSpec.describe LyberCore::Robot do
       expect(workflow_process).not_to have_received(:update).with(hash_including(status: 'started'))
     end
   end
+
+  context 'when the provided version is above the current version (happens with OCR and speech to text workflows)' do
+    let(:cocina_version) { 1 }
+
+    it 'performs normally' do
+      robot.perform(druid, 2)
+      expect(Tester).to have_received(:bare_druid)
+      expect(logger).to have_received(:info).with(/#{druid} processing/)
+      expect(logger).to have_received(:info).with('work done!')
+      expect(Dor::Services::Client).to have_received(:object).with(druid)
+
+      expect(workflow_process).to have_received(:update).with(status: 'completed',
+                                                              elapsed: Float,
+                                                              note: Socket.gethostname,
+                                                              version: 2)
+    end
+  end
 end

--- a/spec/lyber_core/robot_spec.rb
+++ b/spec/lyber_core/robot_spec.rb
@@ -31,7 +31,12 @@ RSpec.describe LyberCore::Robot do
   let(:wf_name) { 'testWF' }
   let(:step_name) { 'test-step' }
   let(:process_response) { instance_double(Dor::Services::Response::Process, lane_id: 'lane1', context: {}, status: 'queued') }
-  let(:workflow_response) { instance_double(Dor::Services::Response::Workflow, process_for_recent_version: process_response, xml: '') }
+  let(:queued_process_response) { instance_double(Dor::Services::Response::Process, active_version?: active_version) }
+  let(:active_version) { true }
+  let(:workflow_response) do
+    instance_double(Dor::Services::Response::Workflow, process_for_recent_version: process_response,
+                                                       process_for: queued_process_response, xml: '')
+  end
   let(:object_workflow) do
     instance_double(Dor::Services::Client::ObjectWorkflow, process: workflow_process, find: workflow_response)
   end
@@ -228,9 +233,9 @@ RSpec.describe LyberCore::Robot do
     end
   end
 
-  context 'when the provided version has been superseded by a newer version' do
-    let(:cocina_version) { 3 }
-    let(:note) { /queued for version 2 but the current object version is 3/ }
+  context 'when the provided version is not the active version (not normal)' do
+    let(:active_version) { false }
+    let(:note) { /queued for version 2 of test-step \(testWF\), but that is not the active version/ }
 
     it 'skips the job without performing the work' do
       robot.perform(druid, 2)
@@ -241,11 +246,12 @@ RSpec.describe LyberCore::Robot do
                                                               note:,
                                                               version: 2)
       expect(workflow_process).not_to have_received(:update).with(hash_including(status: 'started'))
+      expect(workflow_response).to have_received(:process_for).with(name: step_name, version: 2)
     end
   end
 
-  context 'when the provided version is above the current version (happens with OCR and speech to text workflows)' do
-    let(:cocina_version) { 1 }
+  context 'when the provided version is the active version (happy path)' do
+    let(:active_version) { true }
 
     it 'performs normally' do
       robot.perform(druid, 2)

--- a/spec/lyber_core/workflow_spec.rb
+++ b/spec/lyber_core/workflow_spec.rb
@@ -5,8 +5,12 @@ describe LyberCore::Workflow do
     described_class.new(object_client:, workflow_name: 'workflow', process: 'process', version:)
   end
   let(:version) { 2 }
-  let(:process_response) { instance_double(Dor::Services::Response::Process, lane_id:, context:, status:) }
-  let(:workflow_response) { instance_double(Dor::Services::Response::Workflow, process_for_recent_version: process_response) }
+  let(:process_response) { instance_double(Dor::Services::Response::Process, lane_id:, context:, status:, active_version?: active_version) }
+  let(:workflow_response) do
+    instance_double(Dor::Services::Response::Workflow, process_for_recent_version: process_response,
+                                                       process_for: process_response)
+  end
+  let(:active_version) { true }
   let(:object_workflow) { instance_double(Dor::Services::Client::ObjectWorkflow, process: workflow_process, find: workflow_response) }
   let(:object_client) { instance_double(Dor::Services::Client::Object, workflow: object_workflow) }
   let(:workflow_process) { instance_double(Dor::Services::Client::Process, update: nil, update_error: nil) }
@@ -77,6 +81,21 @@ describe LyberCore::Workflow do
   describe '#version' do
     it 'returns the version' do
       expect(workflow.version).to eq(version)
+    end
+  end
+
+  describe '#active_version?' do
+    it 'delegates to the process for the given version' do
+      expect(workflow.active_version?).to be true
+      expect(workflow_response).to have_received(:process_for).with(name: 'process', version:)
+    end
+
+    context 'when the process is not for the active version' do
+      let(:active_version) { false }
+
+      it 'returns false' do
+        expect(workflow.active_version?).to be false
+      end
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Use the new ability to check for active versions of a workflow step to allow robots to determine if the queued step is for an active workflow version (and skip if not).

Next up: release gem, bump all consumers and integration test.

## How was this change tested? 🤨

Specs