### PR TITLE
Allow providing version for test_perform.

### DIFF
--- a/lib/lyber_core/rspec.rb
+++ b/lib/lyber_core/rspec.rb
@@ -3,8 +3,9 @@
 module LyberCore
   # Methods to support testing robots
   module Rspec
-    def test_perform(robot, druid)
+    def test_perform(robot, druid, version: nil)
       allow(robot).to receive(:druid).and_return(druid)
+      allow(robot).to receive(:version).and_return(version) if version
       robot.perform_work
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔
So that it can be used for testing in DSA robots.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that use robots*** (e.g accessioning, create_preassembly_image_spec for preservation) and/or test in [stage|qa] environment (was_robot_suite, gis_robot_suite), in addition to specs. ⚡


